### PR TITLE
Refactor stream callback to avoid dependency on ClientChannel

### DIFF
--- a/packages/zosuss/__tests__/__system__/api/Shell.system.test.ts
+++ b/packages/zosuss/__tests__/__system__/api/Shell.system.test.ts
@@ -12,7 +12,6 @@
 import { Shell, SshSession } from "../../../index";
 import { ITestEnvironment } from "../../../../../__tests__/__src__/environment/doc/response/ITestEnvironment";
 import { TestEnvironment } from "../../../../../__tests__/__src__/environment/TestEnvironment";
-import { ClientChannel } from "ssh2";
 import { TestProperties } from "../../../../../__tests__/__src__/properties/TestProperties";
 import { ITestSystemSchema } from "../../../../../__tests__/__src__/properties/ITestSystemSchema";
 
@@ -41,12 +40,10 @@ describe("zowe uss issue ssh api call test", () => {
     it ("should execute uname command on the remote system by ssh and return operating system name", async () => {
         const command = "uname";
         let stdoutData: string;
-        await Shell.executeSsh(SSH_SESSION, command, (stream: ClientChannel) => {
-            stream.on("data", (data: string) => {
-                if (!data.includes("exit")) {
-                    stdoutData += data;
-                }
-            });
+        await Shell.executeSsh(SSH_SESSION, command, (data: string) => {
+            if (!data.includes("exit")) {
+                stdoutData += data;
+            }
         });
         expect(stdoutData).toMatch("OS/390");
 
@@ -56,12 +53,10 @@ describe("zowe uss issue ssh api call test", () => {
         const command = "pwd";
         const cwd =  `${defaultSystem.unix.testdir}/`;
         let stdoutData: string;
-        await Shell.executeSshCwd(SSH_SESSION, command, cwd, (stream: ClientChannel) => {
-            stream.on("data", (data: string) => {
-                if (!data.includes("exit")) {
-                    stdoutData += data;
-                }
-            });
+        await Shell.executeSshCwd(SSH_SESSION, command, cwd, (data: string) => {
+            if (!data.includes("exit")) {
+                stdoutData += data;
+            }
         });
         expect(stdoutData).toMatch(new RegExp("\\" + cwd + "\\s"));
     }, TIME_OUT);

--- a/packages/zosuss/__tests__/__system__/api/Shell.system.test.ts
+++ b/packages/zosuss/__tests__/__system__/api/Shell.system.test.ts
@@ -54,9 +54,7 @@ describe("zowe uss issue ssh api call test", () => {
         const cwd =  `${defaultSystem.unix.testdir}/`;
         let stdoutData: string;
         await Shell.executeSshCwd(SSH_SESSION, command, cwd, (data: string) => {
-            if (!data.includes("exit")) {
-                stdoutData += data;
-            }
+            stdoutData += data;
         });
         expect(stdoutData).toMatch(new RegExp("\\" + cwd + "\\s"));
     }, TIME_OUT);

--- a/packages/zosuss/src/api/Shell.ts
+++ b/packages/zosuss/src/api/Shell.ts
@@ -46,7 +46,9 @@ export class Shell {
                         resolve();
                     });
                     stream.on("data", (data: string) => {
-                        stdoutHandler(data);
+                        if (!data.includes("exit")) {
+                            stdoutHandler(data);
+                        }
                     });
 
                     // exit multiple times in case of nested shells

--- a/packages/zosuss/src/cli/issue/ssh/Ssh.handler.ts
+++ b/packages/zosuss/src/cli/issue/ssh/Ssh.handler.ts
@@ -22,23 +22,18 @@ import { SshBaseHandler } from "../../../SshBaseHandler";
  */
 export default class Handler extends SshBaseHandler {
 
-    public streamCallBack(stream: ClientChannel) {
-        stream.on("data", (data: string) => {
-            if (!data.includes("exit")) {
-                process.stdout.write(data);
-            }
-        }).stderr.on("data", (data: string) => {
-            if (!data.includes("exit")) {
-                process.stderr.write(data);
-            }
-        });
-    }
 
     public async processCmd(commandParameters: IHandlerParameters) {
         if (commandParameters.arguments.cwd) {
-           await Shell.executeSshCwd(this.mSession, commandParameters.arguments.command, commandParameters.arguments.cwd, this.streamCallBack);
+            await Shell.executeSshCwd(this.mSession, commandParameters.arguments.command, commandParameters.arguments.cwd, this.stdoutHandler);
         } else {
-           await Shell.executeSsh(this.mSession, commandParameters.arguments.command, this.streamCallBack);
+            await Shell.executeSsh(this.mSession, commandParameters.arguments.command, this.stdoutHandler);
+        }
+    }
+
+    private stdoutHandler(data: string) {
+        if (!data.includes("exit")) {
+            process.stdout.write(data);
         }
     }
 }

--- a/packages/zosuss/src/cli/issue/ssh/Ssh.handler.ts
+++ b/packages/zosuss/src/cli/issue/ssh/Ssh.handler.ts
@@ -32,8 +32,6 @@ export default class Handler extends SshBaseHandler {
     }
 
     private stdoutHandler(data: string) {
-        if (!data.includes("exit")) {
-            process.stdout.write(data);
-        }
+        process.stdout.write(data);
     }
 }


### PR DESCRIPTION
When starting to write the `bundle push` command I realised that our existing callback was bit ugly.  It requires the calling code to have a dependency on ssh2 (in my case zowe-cli-cics-deploy-plugin would need to depend on ssh2). It also means if we changed the implementation in future to use a different ssh module, all the calling code would need to change.
What I'm proposing I think is a bit neater - the caller still provides a callback function, but we call that callback whenever data appears on stdout, rather than requiring the user code to handle the stream events directly.
I started off with an extra callback for stderr data, but I seem to remember we found we never actually see data returning on the stderr stream so I don't think we need one for stderr.
